### PR TITLE
CMakeLists: Minor cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,6 @@ endif()
 
 add_subdirectory(lib)
 add_subdirectory(driver)
-target_include_directories(nod PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
-install(DIRECTORY include/nod DESTINATION include)
 
 set(version_config_file "${PROJECT_BINARY_DIR}/nodConfigVersion.cmake")
 set(config_file "${PROJECT_BINARY_DIR}/nodConfig.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,6 @@ if (NOT TARGET logvisor)
   add_subdirectory(logvisor)
 endif()
 
-file(GLOB NOD_HEADERS include/nod/*.h*)
-
 add_subdirectory(lib)
 add_subdirectory(driver)
 target_include_directories(nod PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,6 +21,11 @@ add_library(nod
   ../include/nod/sha1.h
   ../include/nod/Util.hpp
 )
+
+target_include_directories(nod PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+)
+
 target_link_libraries(nod PUBLIC logvisor)
 
 if(WIN32)
@@ -41,3 +46,5 @@ install(
     ARCHIVE DESTINATION "lib"
     INCLUDES DESTINATION include  # This sets the INTERFACE_INCLUDE_DIRECTORIES property of the target.
 )
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../include/nod DESTINATION include)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,14 +1,26 @@
 add_library(nod
-            aes.cpp
-            sha1.c
-            DiscBase.cpp
-            DiscGCN.cpp
-            DiscIOISO.cpp
-            DiscIOWBFS.cpp
-            DiscWii.cpp
-            DirectoryEnumerator.cpp
-            nod.cpp
-            ${NOD_HEADERS})
+  aes.cpp
+  sha1.c
+
+  DirectoryEnumerator.cpp
+  DiscBase.cpp
+  DiscGCN.cpp
+  DiscIOISO.cpp
+  DiscIOWBFS.cpp
+  DiscWii.cpp
+  nod.cpp
+
+  ../include/nod/aes.hpp
+  ../include/nod/DirectoryEnumerator.hpp
+  ../include/nod/DiscBase.hpp
+  ../include/nod/DiscGCN.hpp
+  ../include/nod/DiscWii.hpp
+  ../include/nod/IDiscIO.hpp
+  ../include/nod/IFileIO.hpp
+  ../include/nod/nod.hpp
+  ../include/nod/sha1.h
+  ../include/nod/Util.hpp
+)
 target_link_libraries(nod PUBLIC logvisor)
 
 if(WIN32)


### PR DESCRIPTION
Cleans up a few things related to how the library target is configured. Mainly just avoids configuration of the library target outside of the lib folder to keep everything clearly separated and in one spot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/nod/10)
<!-- Reviewable:end -->
