### PR TITLE
Shift-JIS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,6 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
         /wd4267 /wd4244 /wd4200 /wd4305 /wd4067 /wd4146 /wd4309 /wd4805 ${VS_OPTIONS})
 
     add_compile_options(
-      # Disable exceptions
-      $<$<COMPILE_LANGUAGE:CXX>:/EHsc->
-
       # Disable RTTI
       $<$<COMPILE_LANGUAGE:CXX>:/GR->
 
@@ -30,7 +27,6 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
       # Use latest C++ standard.
       $<$<COMPILE_LANGUAGE:CXX>:/std:c++latest>
     )
-    add_compile_definitions(FMT_EXCEPTIONS=0 _HAS_EXCEPTIONS=0)
 
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
       # Flags for MSVC (not clang-cl)

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -66,11 +66,12 @@ int main(int argc, char* argv[])
   }
 
   auto progFunc = [&](float prog, nod::SystemStringView name, size_t bytes) {
-    fmt::print(FMT_STRING(_SYS_STR("\r                                                                      ")));
+    nod::SystemShiftJISConv shiftjis_name(name);
+    fmt::print(FMT_STRING("\r                                                                      "));
     if (bytes != SIZE_MAX)
-      fmt::print(FMT_STRING(_SYS_STR("\r{:g}% {} {} B")), prog * 100.f, name, bytes);
+      fmt::print(FMT_STRING("\r{:g}% {} {} B"), prog * 100.f, shiftjis_name.shiftjis_str(), bytes);
     else
-      fmt::print(FMT_STRING(_SYS_STR("\r{:g}% {}")), prog * 100.f, name);
+      fmt::print(FMT_STRING("\r{:g}% {}"), prog * 100.f, shiftjis_name.shiftjis_str());
     fflush(stdout);
   };
 

--- a/include/nod/DiscBase.hpp
+++ b/include/nod/DiscBase.hpp
@@ -410,9 +410,9 @@ public:
     static bool RecursiveCalculateTotalSize(uint64_t& totalSz, const Node* nodeIn, SystemStringView dirIn);
 
     void addBuildName(SystemStringView str) {
-      SystemUTF8Conv utf8View(str);
-      m_buildNames.emplace_back(utf8View.utf8_str());
-      m_buildNameOff += utf8View.utf8_str().size() + 1;
+      SystemShiftJISConv shiftjisView(str);
+      m_buildNames.emplace_back(shiftjisView.shiftjis_str());
+      m_buildNameOff += shiftjisView.shiftjis_str().size() + 1;
     }
 
     DiscBuilderBase& m_parent;

--- a/include/nod/DiscBase.hpp
+++ b/include/nod/DiscBase.hpp
@@ -412,7 +412,7 @@ public:
     void addBuildName(SystemStringView str) {
       SystemUTF8Conv utf8View(str);
       m_buildNames.emplace_back(utf8View.utf8_str());
-      m_buildNameOff += str.size() + 1;
+      m_buildNameOff += utf8View.utf8_str().size() + 1;
     }
 
     DiscBuilderBase& m_parent;

--- a/include/nod/Util.hpp
+++ b/include/nod/Util.hpp
@@ -3,7 +3,6 @@
 #if _WIN32 && UNICODE
 #include <cwctype>
 #include <direct.h>
-#define CP_SHIFT_JIS 932
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN 1
 #endif
@@ -11,6 +10,7 @@
 #define NOMINMAX
 #endif
 #include <windows.h>
+#define CP_SHIFT_JIS 932
 #if defined(WINAPI_FAMILY) && WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP
 #define WINDOWS_STORE 1
 #else

--- a/include/nod/Util.hpp
+++ b/include/nod/Util.hpp
@@ -3,6 +3,7 @@
 #if _WIN32 && UNICODE
 #include <cwctype>
 #include <direct.h>
+#define CP_SHIFT_JIS 932
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN 1
 #endif
@@ -97,9 +98,9 @@ class SystemUTF8Conv {
 
 public:
   explicit SystemUTF8Conv(SystemStringView str) {
-    int len = WideCharToMultiByte(CP_UTF8, 0, str.data(), str.size(), nullptr, 0, nullptr, nullptr);
+    const size_t len = WideCharToMultiByte(CP_SHIFT_JIS, 0, str.data(), str.size(), nullptr, 0, nullptr, nullptr);
     m_utf8.assign(len, '\0');
-    WideCharToMultiByte(CP_UTF8, 0, str.data(), str.size(), &m_utf8[0], len, nullptr, nullptr);
+    WideCharToMultiByte(CP_SHIFT_JIS, 0, str.data(), str.size(), &m_utf8[0], len, nullptr, nullptr);
   }
   std::string_view utf8_str() const { return m_utf8; }
   const char* c_str() const { return m_utf8.c_str(); }
@@ -109,9 +110,9 @@ class SystemStringConv {
 
 public:
   explicit SystemStringConv(std::string_view str) {
-    int len = MultiByteToWideChar(CP_UTF8, 0, str.data(), str.size(), nullptr, 0);
+    const size_t len = MultiByteToWideChar(CP_SHIFT_JIS, 0, str.data(), str.size(), nullptr, 0);
     m_sys.assign(len, L'\0');
-    MultiByteToWideChar(CP_UTF8, 0, str.data(), str.size(), &m_sys[0], len);
+    MultiByteToWideChar(CP_SHIFT_JIS, 0, str.data(), str.size(), &m_sys[0], len);
   }
   SystemStringView sys_str() const { return m_sys; }
   const SystemChar* c_str() const { return m_sys.c_str(); }

--- a/include/nod/Util.hpp
+++ b/include/nod/Util.hpp
@@ -93,23 +93,23 @@ typedef std::wstring_view SystemStringView;
 static inline void ToLower(SystemString& str) { std::transform(str.begin(), str.end(), str.begin(), towlower); }
 static inline void ToUpper(SystemString& str) { std::transform(str.begin(), str.end(), str.begin(), towupper); }
 static inline size_t StrLen(const SystemChar* str) { return wcslen(str); }
-class SystemUTF8Conv {
-  std::string m_utf8;
+class SystemShiftJISConv {
+  std::string m_shiftjis;
 
 public:
-  explicit SystemUTF8Conv(SystemStringView str) {
+  explicit SystemShiftJISConv(SystemStringView str) {
     const size_t len = WideCharToMultiByte(CP_SHIFT_JIS, 0, str.data(), str.size(), nullptr, 0, nullptr, nullptr);
-    m_utf8.assign(len, '\0');
-    WideCharToMultiByte(CP_SHIFT_JIS, 0, str.data(), str.size(), &m_utf8[0], len, nullptr, nullptr);
+    m_shiftjis.assign(len, '\0');
+    WideCharToMultiByte(CP_SHIFT_JIS, 0, str.data(), str.size(), &m_shiftjis[0], len, nullptr, nullptr);
   }
-  std::string_view utf8_str() const { return m_utf8; }
-  const char* c_str() const { return m_utf8.c_str(); }
+  std::string_view shiftjis_str() const { return m_shiftjis; }
+  const char* c_str() const { return m_shiftjis.c_str(); }
 };
-class SystemStringConv {
+class ShiftJISSystemConv {
   std::wstring m_sys;
 
 public:
-  explicit SystemStringConv(std::string_view str) {
+  explicit ShiftJISSystemConv(std::string_view str) {
     const size_t len = MultiByteToWideChar(CP_SHIFT_JIS, 0, str.data(), str.size(), nullptr, 0);
     m_sys.assign(len, L'\0');
     MultiByteToWideChar(CP_SHIFT_JIS, 0, str.data(), str.size(), &m_sys[0], len);


### PR DESCRIPTION
When converting to and from wstrings, the Shift-JIS codepage is now being used instead of the UTF-8 codepage.

Fixed a bug in nod::DiscBuilderBase::PartitionBuilderBase::addBuildName(nod::SystemStringView) that corrupted the filesystem table if the multibyte string is longer than the wstring it came from.