### PR TITLE
The Encoding Update

### DIFF
--- a/include/nod/DiscGCN.hpp
+++ b/include/nod/DiscGCN.hpp
@@ -7,10 +7,10 @@ class DiscBuilderGCN;
 
 class DiscGCN : public DiscBase {
   friend class DiscMergerGCN;
-  DiscBuilderGCN makeMergeBuilder(SystemStringView outPath, FProgress progressCB);
+  DiscBuilderGCN makeMergeBuilder(SystemStringView outPath, FProgress progressCB, Codepage_t codepage);
 
 public:
-  DiscGCN(std::unique_ptr<IDiscIO>&& dio, bool& err);
+  DiscGCN(std::unique_ptr<IDiscIO>&& dio, bool& err, Codepage_t codepage = CP_US_ASCII);
   bool extractDiscHeaderFiles(SystemStringView path, const ExtractionContext& ctx) const override;
 };
 
@@ -18,9 +18,9 @@ class DiscBuilderGCN : public DiscBuilderBase {
   friend class DiscMergerGCN;
 
 public:
-  DiscBuilderGCN(SystemStringView outPath, FProgress progressCB);
+  DiscBuilderGCN(SystemStringView outPath, FProgress progressCB, Codepage_t codepage = CP_US_ASCII);
   EBuildResult buildFromDirectory(SystemStringView dirIn);
-  static std::optional<uint64_t> CalculateTotalSizeRequired(SystemStringView dirIn);
+  static std::optional<uint64_t> CalculateTotalSizeRequired(SystemStringView dirIn, Codepage_t codepage = CP_US_ASCII);
 };
 
 class DiscMergerGCN {
@@ -28,9 +28,9 @@ class DiscMergerGCN {
   DiscBuilderGCN m_builder;
 
 public:
-  DiscMergerGCN(SystemStringView outPath, DiscGCN& sourceDisc, FProgress progressCB);
+  DiscMergerGCN(SystemStringView outPath, DiscGCN& sourceDisc, FProgress progressCB, Codepage_t codepage = CP_US_ASCII);
   EBuildResult mergeFromDirectory(SystemStringView dirIn);
-  static std::optional<uint64_t> CalculateTotalSizeRequired(DiscGCN& sourceDisc, SystemStringView dirIn);
+  static std::optional<uint64_t> CalculateTotalSizeRequired(DiscGCN& sourceDisc, SystemStringView dirIn, Codepage_t codepage = CP_US_ASCII);
 };
 
 } // namespace nod

--- a/include/nod/DiscWii.hpp
+++ b/include/nod/DiscWii.hpp
@@ -7,16 +7,16 @@ class DiscBuilderWii;
 
 class DiscWii : public DiscBase {
 public:
-  DiscWii(std::unique_ptr<IDiscIO>&& dio, bool& err);
-  DiscBuilderWii makeMergeBuilder(SystemStringView outPath, bool dualLayer, FProgress progressCB);
+  DiscWii(std::unique_ptr<IDiscIO>&& dio, bool& err, Codepage_t codepage = CP_US_ASCII);
+  DiscBuilderWii makeMergeBuilder(SystemStringView outPath, bool dualLayer, FProgress progressCB, Codepage_t codepage);
   bool extractDiscHeaderFiles(SystemStringView path, const ExtractionContext& ctx) const override;
 };
 
 class DiscBuilderWii : public DiscBuilderBase {
 public:
-  DiscBuilderWii(SystemStringView outPath, bool dualLayer, FProgress progressCB);
+  DiscBuilderWii(SystemStringView outPath, bool dualLayer, FProgress progressCB, Codepage_t codepage = CP_US_ASCII);
   EBuildResult buildFromDirectory(SystemStringView dirIn);
-  static std::optional<uint64_t> CalculateTotalSizeRequired(SystemStringView dirIn, bool& dualLayer);
+  static std::optional<uint64_t> CalculateTotalSizeRequired(SystemStringView dirIn, bool& dualLayer, Codepage_t codepage = CP_US_ASCII);
 };
 
 class DiscMergerWii {
@@ -24,9 +24,9 @@ class DiscMergerWii {
   DiscBuilderWii m_builder;
 
 public:
-  DiscMergerWii(SystemStringView outPath, DiscWii& sourceDisc, bool dualLayer, FProgress progressCB);
+  DiscMergerWii(SystemStringView outPath, DiscWii& sourceDisc, bool dualLayer, FProgress progressCB, Codepage_t codepage = CP_US_ASCII);
   EBuildResult mergeFromDirectory(SystemStringView dirIn);
-  static std::optional<uint64_t> CalculateTotalSizeRequired(DiscWii& sourceDisc, SystemStringView dirIn, bool& dualLayer);
+  static std::optional<uint64_t> CalculateTotalSizeRequired(DiscWii& sourceDisc, SystemStringView dirIn, bool& dualLayer, Codepage_t codepage = CP_US_ASCII);
 };
 
 } // namespace nod

--- a/include/nod/nod.hpp
+++ b/include/nod/nod.hpp
@@ -12,10 +12,10 @@ class DiscBase;
 
 struct ExtractionContext final {
   bool force : 1;
-  std::function<void(std::string_view, float)> progressCB;
+  std::function<void(nod::SystemStringView, float)> progressCB;
 };
 
 std::unique_ptr<DiscBase> OpenDiscFromImage(SystemStringView path);
-std::unique_ptr<DiscBase> OpenDiscFromImage(SystemStringView path, bool& isWii);
+std::unique_ptr<DiscBase> OpenDiscFromImage(SystemStringView path, bool& isWii, Codepage_t codepage = CP_US_ASCII);
 
 } // namespace nod

--- a/lib/nod.cpp
+++ b/lib/nod.cpp
@@ -14,7 +14,7 @@ std::unique_ptr<IDiscIO> NewDiscIOISO(SystemStringView path);
 std::unique_ptr<IDiscIO> NewDiscIOWBFS(SystemStringView path);
 std::unique_ptr<IDiscIO> NewDiscIONFS(SystemStringView path);
 
-std::unique_ptr<DiscBase> OpenDiscFromImage(SystemStringView path, bool& isWii) {
+std::unique_ptr<DiscBase> OpenDiscFromImage(SystemStringView path, bool& isWii, Codepage_t codepage) {
   /* Temporary file handle to determine image type */
   std::unique_ptr<IFileIO> fio = NewFileIO(path);
   if (!fio->exists()) {
@@ -67,13 +67,13 @@ std::unique_ptr<DiscBase> OpenDiscFromImage(SystemStringView path, bool& isWii) 
   bool err = false;
   std::unique_ptr<DiscBase> ret;
   if (isWii) {
-    ret = std::make_unique<DiscWii>(std::move(discIO), err);
+    ret = std::make_unique<DiscWii>(std::move(discIO), err, codepage);
     if (err)
       return {};
     return ret;
   }
 
-  ret = std::make_unique<DiscGCN>(std::move(discIO), err);
+  ret = std::make_unique<DiscGCN>(std::move(discIO), err, codepage);
   if (err)
     return {};
   return ret;
@@ -81,7 +81,7 @@ std::unique_ptr<DiscBase> OpenDiscFromImage(SystemStringView path, bool& isWii) 
 
 std::unique_ptr<DiscBase> OpenDiscFromImage(SystemStringView path) {
   bool isWii;
-  return OpenDiscFromImage(path, isWii);
+  return OpenDiscFromImage(path, isWii, CP_US_ASCII);
 }
 
 } // namespace nod


### PR DESCRIPTION
While Nintendo's own documents claim GameCube and Wii disc file symbol tables only support 7-bit ASCII, this is far from the truth.  Indeed, even some first-party Nintendo games shipped with Shift-JIS encoded file symbol tables.  My guess?  The locale of whatever Windows machine mastered a GameCube or Wii disc influenced how wide character strings (UCS-2) were converted to narrow character strings.  To account for all possibilites, this update adds extensible multi-byte character set options to NOD-Tool.

A rundown of notable changes:
 - "-c XXXXX" option added to set the encoding of the GameCube / Wii ISO(s) being processed.
 - "SystemStringConv" renamed to "DiscLocToSystemConv"
 - "SystemUTF8Conv" renamed to "SystemToDiscLocConv"
 - Help message updated with new info.
 - Bugfix: AddBuildName had a logic error wherein the length of the SystemString was being used instead of length of the disc locale string.  This would corrupt the File Symbol Table if the disc locale string's length was greater than the SystemString's length.
 - Bugfix: recursiveMergeFST was not keeping track of parent indexes at all, meaning nested folders and their contents would be corrupted.  I simply copied the way recursiveBuildFST did things to fix this.
 - Bugfix (Windows): On Windows, for some reason, Sstat was a typedef for _stat (32-bit) instead of _stat64 (64-bit).  This is confounding, because untrimmed Wii ISOs will always be larger than the unsigned 32-bit integer limit (4,699,979,776 bytes vs 4,294,967,295 bytes), meaning the MergeWii errand has never worked for untrimmed ISOs on Windows.  Was this never tested??
 - Bugfix (Windows): Did you know Windows Command Prompt fully supports Unicode?  Stdio streams are now in _O_U16TEXT mode for Windows only.  Previously, attempting to print any character that could not be narrowed to your locale's encoding would either silently fail (std functions), or throw an exception (fmt functions).  As a minor drawback, narrow character print functions can no longer be used when stdio is in _O_U16TEXT mode, necessitating my PR for Logvisor here: (https://github.com/AxioDL/logvisor/pull/7)
 - ExtractionContext::progressCB now uses SystemStringView because widechar printing works correctly on Windows now.
 - progFunc lambda no longer throws exceptions when printing unicode because widechar printing works correctly on Windows now.
 - Top-level constructors and functions with a Codepage_t parameter have also signatures that default to the US-ASCII codepage.
    - DiscGCN constructor
    - DiscBuilderGCN constructor
    - DiscBuilderGCN::CalculateTotalSizeRequired
    - DiscMergerGCN constructor
    - DiscMergerGCN::CalculateTotalSizeRequired
    - DiscWii constructor
    - DiscBuilderWii constructor
    - DiscBuilderWii::CalculateTotalSizeRequired
    - DiscMergerWii constructor
    - DiscMergerWii::CalculateTotalSizeRequired
    - OpenDiscFromImage
 - Conversion between system encoding and disc locale encoding has checks in place to warn the user if string conversion goes awry.